### PR TITLE
Fix Qt 5.15 compatibility changes

### DIFF
--- a/src/kdmactouchbar.mm
+++ b/src/kdmactouchbar.mm
@@ -42,9 +42,9 @@ NSImage *qt_mac_create_nsimage(const QIcon &icon, int defaultSize = 0);
 #else
 //  defined in gui/painting/qcoregraphics.mm
 @interface NSImage (QtExtras)
-+ (instancetype)imageFromQIcon:(const QIcon &)icon
++ (instancetype)imageFromQIcon:(const QIcon &)icon;
 @end
-NSImage *qt_mac_create_nsimage(const QIcon &icon)
+static NSImage *qt_mac_create_nsimage(const QIcon &icon)
 {
     return [NSImage imageFromQIcon:icon];
 }


### PR DESCRIPTION
Regarding a7db88b:

Missing semicolon on the prototype.
Also added a `static` to `qt_mac_create_nsimage` since that triggered an error when using some strict compile flags.