### PR TITLE
Standardize project to KDAB copyright policy

### DIFF
--- a/LICENSE.LGPL.txt
+++ b/LICENSE.LGPL.txt
@@ -1,5 +1,5 @@
 
- KDMacTouchBar is Copyright (C) 2019-2023 Klarälvdalens Datakonsult AB.
+ KDMacTouchBar is © Klarälvdalens Datakonsult AB.
 
  You may use, distribute and copy KDMacTouchBar under the terms of
  GNU Lesser General Public License version 3, which is displayed below.

--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ touchBar->addAction(actionSaveFile);
 ```
 
 ## Licensing:
-KD MacTouchBar is (C) 2019-2023, Klarälvdalens Datakonsult AB,
-and is available under the terms of:
+KD MacTouchBar is © Klarälvdalens Datakonsult AB and is available under the terms of:
 
 * the LGPL (see LICENSE.LGPL.txt for details)
 * the KDAB commercial license, provided that you buy a license.

--- a/examples/mactouchbar/main.cpp
+++ b/examples/mactouchbar/main.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
-** Copyright (C) 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com.
+** Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com.
 ** All rights reserved.
 **
 ** This file is part of the KD MacTouchBar library.

--- a/examples/mactouchbar/mainwindow.cpp
+++ b/examples/mactouchbar/mainwindow.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************
-** Copyright (C) 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com.
+** Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com.
 ** All rights reserved.
 **
 ** This file is part of the KD MacTouchBar library.

--- a/examples/mactouchbar/mainwindow.h
+++ b/examples/mactouchbar/mainwindow.h
@@ -1,5 +1,5 @@
 /****************************************************************************
-** Copyright (C) 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com.
+** Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com.
 ** All rights reserved.
 **
 ** This file is part of the KD MacTouchBar library.

--- a/src/kdmactouchbar.h
+++ b/src/kdmactouchbar.h
@@ -1,5 +1,5 @@
 /****************************************************************************
-** Copyright (C) 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com.
+** Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com.
 ** All rights reserved.
 **
 ** This file is part of the KD MacTouchBar library.

--- a/src/kdmactouchbar.mm
+++ b/src/kdmactouchbar.mm
@@ -1,5 +1,5 @@
 /****************************************************************************
-** Copyright (C) 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com.
+** Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com.
 ** All rights reserved.
 **
 ** This file is part of the KD MacTouchBar library.

--- a/src/kdmactouchbar_global.h
+++ b/src/kdmactouchbar_global.h
@@ -1,5 +1,5 @@
 /****************************************************************************
-** Copyright (C) 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com.
+** Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com.
 ** All rights reserved.
 **
 ** This file is part of the KD MacTouchBar library.


### PR DESCRIPTION
For individual files: use year of file creation
For entire project:
  remove year from the statement
  use the © where feasible

reference:
https://matija.suklje.name/how-and-why-to-properly-write-copyright-statements-in-your-code